### PR TITLE
feat: expose `uuid` field for products

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,7 @@ export type ProductModel = {
 
 export type Product = {
   identifier: string;
+  uuid?: string;
   enabled: boolean;
   family: string;
   categories: string[];


### PR DESCRIPTION
According to https://api.akeneo.com/getting-started/from-identifiers-to-uuid-7x/welcome.html, akeneo Serenity started to introduce `uuid`, advising to switch over to it.

This PR is about to expose this new field for products for now, not yet making any further use of  it, but rather enabling consumers to gather this info.