### PR TITLE
fix: use correct params for category.getAll()

### DIFF
--- a/src/endpoints/category.spec.ts
+++ b/src/endpoints/category.spec.ts
@@ -74,9 +74,16 @@ describe('Category', () => {
       Promise.resolve({ data: mockCategoryResponse.getAll }),
     );
 
-    const { items: categories } = await getAll(axios, {});
+    const { items: categories } = await getAll(axios, {
+      query: {
+        search: JSON.stringify({
+          parent: [{ operator: '=', value: 'some category' }],
+        }),
+      },
+    });
     expect(axios.get).toBeCalledWith('/api/rest/v1/categories', {
       params: {
+        search: '{"parent":[{"operator":"=","value":"some category"}]}',
         limit: 100,
         page: 1,
         with_count: true,

--- a/src/endpoints/category.ts
+++ b/src/endpoints/category.ts
@@ -40,5 +40,5 @@ export const getAll = (
   params: { query?: CategoryQueryParameters },
 ): Promise<ListResponse<Category>> =>
   raw.getAllByPage(http, `/api/rest/v1/categories`, {
-    params,
+    params: params.query,
   });


### PR DESCRIPTION
fixes 
![image](https://github.com/user-attachments/assets/f3748cbd-f1db-44be-91bb-221f98a2b4f7)
