### PR TITLE
fix: mark current_page as required

### DIFF
--- a/packages/client/src/lib/types.ts
+++ b/packages/client/src/lib/types.ts
@@ -110,7 +110,7 @@ export type AssetQueryParameters = {
 
 export type ListResponse<T> = {
   items_count?: number;
-  current_page?: number;
+  current_page: number;
   items: T[];
 };
 


### PR DESCRIPTION
`current_page` cannot be undefined for any of the list responses from the akeneo REST api